### PR TITLE
typo: symlinking

### DIFF
--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -69,7 +69,7 @@ impl Module {
 
     pub fn link(&self, file: File) -> Result<(), Box<dyn Error>> {
         println!(
-            "Symlining file {:?} to {:?}",
+            "Symlinking file {:?} to {:?}",
             self.root_dir
                 .clone()
                 .unwrap()


### PR DESCRIPTION
Fixes small typo "symlining --> symlinking"