### PR TITLE
ensure directories are created

### DIFF
--- a/src/manifests/mod.rs
+++ b/src/manifests/mod.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, path::PathBuf};
+use std::{error::Error, fs::create_dir_all, path::PathBuf};
 
 use crate::files::File;
 use crate::packages::PackageConfig;
@@ -50,6 +50,23 @@ impl Manifest {
                 .unwrap()
                 .join(file.clone().to.unwrap())
         );
+        let mut parent = self
+            .root_dir
+            .clone()
+            .unwrap()
+            .join(file.clone().to.unwrap());
+
+        parent.pop();
+        
+        println!(
+            "Creating directory {:?}",
+            parent
+                .clone()
+                .to_str()
+                
+        );
+        create_dir_all(parent)?;
+
         let mut f = std::fs::File::create(
             self.root_dir
                 .clone()


### PR DESCRIPTION
This change runs create_dir_all on the base directory of a file in the files module before attempting to write it.